### PR TITLE
Add key press events on changing speed to fix UI desync

### DIFF
--- a/chrome/youtube/js/category-player.js
+++ b/chrome/youtube/js/category-player.js
@@ -64,8 +64,22 @@ function video_playback_speed() {
     var data = Number(settings.video_playback_speed),
         player = document.querySelector('.html5-video-player');
 
-    if (data)
+    if (data) {
         player.querySelector('video').playbackRate = data;
+		
+		//HACK the YT UI doesn't read the player's playback rate
+		//    by using the keyboard shortcuts to increase the speed and then decrease the speed,
+		//    the UI updates to the player's speed
+		var evnt = document.createEvent("HTMLEvents").initEvent("keydown", true, false);
+		evnt.shiftKey = true;
+		
+		evnt.keyCode = 188; // ">" keypress
+		document.dispatchEvent(evnt);
+		
+		evnt.keyCode = 188; // "<" keypress
+		document.dispatchEvent(evnt);
+		
+	}
 }
 
 

--- a/firefox/youtube/js/category-player.js
+++ b/firefox/youtube/js/category-player.js
@@ -61,6 +61,18 @@ function video_playback_speed() {
 
     if (data && data != 'do_not_change') {
         player.querySelector('video').playbackRate = Number(data);
+		
+		//HACK the YT UI doesn't read the player's playback rate
+		//    by using the keyboard shortcuts to increase the speed and then decrease the speed,
+		//    the UI updates to the player's speed
+		var evnt = document.createEvent("HTMLEvents").initEvent("keydown", true, false);
+		evnt.shiftKey = true;
+		
+		evnt.keyCode = 188; // ">" keypress
+		document.dispatchEvent(evnt);
+		
+		evnt.keyCode = 188; // "<" keypress
+		document.dispatchEvent(evnt);
     }
 }
 


### PR DESCRIPTION
It seems the YouTube speed UI does not pull from the HTML player's speed but some other location (or just defaults to normal until actual user interaction).
This PR temporarily fixes this issue by quickly sending the increase speed (">") and decrease speed ("<") key shortcuts to the player to force the UI to match the player's playback speed.

This should later be properly fixed by somehow forcing the YouTube UI to match the player's speed without the excessive and intrusive (shows shortcut acknowledgment icon on display, but for the time being this solution should work.

Should solve #46 