### PR TITLE
Stops breaking native dark mode.

### DIFF
--- a/chrome/youtube/js/category-general.js
+++ b/chrome/youtube/js/category-general.js
@@ -37,16 +37,13 @@ function it_theme() {
     document.documentElement.setAttribute('dark', '');
     document.documentElement.setAttribute('it-theme', data);
   } else {
-    document.documentElement.removeAttribute('dark');
     document.documentElement.removeAttribute('it-theme');
 
 		if (document.querySelector('ytd-masthead')) {
-			document.querySelector('ytd-masthead').removeAttribute('dark');
 			document.querySelector('ytd-masthead').removeAttribute('style');
 		}
 
 		if (document.querySelector('ytd-app')) {
-			document.querySelector('ytd-app').removeAttribute('dark');
 			document.querySelector('ytd-app').removeAttribute('style');
 		}
   }


### PR DESCRIPTION
Currently using native dark mode without ImprovedTube dark mode is impossible as it removes the dark attribute on page load. ImprovedTube's dark mode causes issues elsewhere (creator studio) so I changed it to make it stop removing the dark attribute. Light mode users turning off an ImprovedTube theme will have to refresh to get off dark mode, but that's better than native dark mode not working at all.