### PR TITLE
Fix (LOW): Settings Home label shown as "undefined"

### DIFF
--- a/template/template-parts/settings.js
+++ b/template/template-parts/settings.js
@@ -15,7 +15,7 @@ Menu.main.section.settings = {
 
                 home: {
                     type: 'folder',
-                    label: 'Home',
+                    label: 'home',
 
                     section: {
                         type: 'section',


### PR DESCRIPTION
Hi, my first constribution with a very low priority fix. The Home label in the settings is shown as "undefined".