### PR TITLE
Fix: "Cannot read property 'getBoundingClientRect' of null" when Icon is Disabled

### DIFF
--- a/youtube/js/features/settings.js
+++ b/youtube/js/features/settings.js
@@ -13,11 +13,11 @@
 ImprovedTube.improvedtube_youtube_icon_wait = false;
 
 ImprovedTube.improvedtube_youtube_icon_resize = function() {
-    var option = ImprovedTube.storage.improvedtube_youtube_icon;
+    var iframe = document.querySelector('.it-btn__iframe'),
+        option = ImprovedTube.storage.improvedtube_youtube_icon;
     
     if (iframe && option !== 'disabled') {
-        var iframe = document.querySelector('.it-btn__iframe'),
-            icon = document.querySelector('.it-btn__icon'),
+        var icon = document.querySelector('.it-btn__icon'),
             x = icon.getBoundingClientRect().x,
             y = icon.getBoundingClientRect().y;
 

--- a/youtube/js/features/settings.js
+++ b/youtube/js/features/settings.js
@@ -13,12 +13,14 @@
 ImprovedTube.improvedtube_youtube_icon_wait = false;
 
 ImprovedTube.improvedtube_youtube_icon_resize = function() {
-    var iframe = document.querySelector('.it-btn__iframe'),
-        icon = document.querySelector('.it-btn__icon'),
-        x = icon.getBoundingClientRect().x,
-        y = icon.getBoundingClientRect().y;
+    var option = ImprovedTube.storage.improvedtube_youtube_icon;
+    
+    if (iframe && option !== 'disabled') {
+        var iframe = document.querySelector('.it-btn__iframe'),
+            icon = document.querySelector('.it-btn__icon'),
+            x = icon.getBoundingClientRect().x,
+            y = icon.getBoundingClientRect().y;
 
-    if (iframe) {
         if (x < window.innerWidth / 2) {
             iframe.style.right = 'auto';
             iframe.style.left = '0px';

--- a/youtube/js/features/settings.js
+++ b/youtube/js/features/settings.js
@@ -14,11 +14,10 @@ ImprovedTube.improvedtube_youtube_icon_wait = false;
 
 ImprovedTube.improvedtube_youtube_icon_resize = function() {
     var iframe = document.querySelector('.it-btn__iframe'),
-        option = ImprovedTube.storage.improvedtube_youtube_icon;
+        icon = document.querySelector('.it-btn__icon');
     
-    if (iframe && option !== 'disabled') {
-        var icon = document.querySelector('.it-btn__icon'),
-            x = icon.getBoundingClientRect().x,
+    if (iframe && icon) {
+        var x = icon.getBoundingClientRect().x,
             y = icon.getBoundingClientRect().y;
 
         if (x < window.innerWidth / 2) {


### PR DESCRIPTION
This will fix the issue that breaks scrolling using the scrollbar when the icon is disabled and the code fails reading an undefined object.

![image](https://user-images.githubusercontent.com/1682040/69899285-be517480-1342-11ea-9f90-024fb9230238.png)
