### PR TITLE
A fix for the SUCCESSFUL SETTINGS IMPORT message.

### DIFF
--- a/template/template-parts/settings.js
+++ b/template/template-parts/settings.js
@@ -454,7 +454,7 @@ Menu.main.section.settings = {
 
                                         message: {
                                             type: 'text',
-                                            label: 'successfullyImportedSettings',
+                                            label: 'settingsSuccessfullyImported',
                                             style: {
                                                 'width': '100%',
                                                 'opacity': '.8'


### PR DESCRIPTION
I've changed ``successfullyImportedSettings`` to ``settingsSuccessfullyImported``.

![2020-04-06_23-35-46](https://user-images.githubusercontent.com/9064159/78609566-3258d780-7863-11ea-8fc1-0dddd2891ecb.png)

The strings between the template and translations were different.

**_locales\\...\messages.json**
```JSON
"settingsSuccessfullyImported": {
    "message": "Settings successfully imported"
},
```

**template\template-parts\settings.js** [BEFORE]
```JAVASCRIPT
message: {
    type: 'text',
    label: 'successfullyImportedSettings',
    style: {
        'width': '100%',
        'opacity': '.8'
    }
},
```
I went with the least-edit path, I hope it's good enough.